### PR TITLE
[FMP-760] Only rewrite implied model names

### DIFF
--- a/lib/action_view/helpers/dynamic_form.rb
+++ b/lib/action_view/helpers/dynamic_form.rb
@@ -210,13 +210,13 @@ module ActionView
               html[key] = 'errorExplanation'
             end
           end
-          options[:object_name] ||= params.first
+          options[:object_name] ||= params.first.to_s.gsub('_', ' ')
 
           I18n.with_options :locale => options[:locale], :scope => [:activerecord, :errors, :template] do |locale|
             header_message = if options.include?(:header_message)
               options[:header_message]
             else
-              locale.t :header, :count => count, :model => options[:object_name].to_s.gsub('_', ' ')
+              locale.t :header, :count => count, :model => options[:object_name].to_s
             end
 
             message = options.include?(:message) ? options[:message] : locale.t(:body)

--- a/test/dynamic_form_test.rb
+++ b/test/dynamic_form_test.rb
@@ -292,9 +292,6 @@ class DynamicFormTest < ActionView::TestCase
     # any default works too
     assert_dom_equal %(<div class="errorExplanation" id="errorExplanation"><h2>2 errors prohibited this monkey from being saved</h2><p>There were problems with the following fields:</p><ul><li>User email can't be empty</li><li>Author name can't be empty</li></ul></div>), error_messages_for(:user, :post, :object_name => "monkey")
 
-    # should space object name
-    assert_dom_equal %(<div class="errorExplanation" id="errorExplanation"><h2>2 errors prohibited this chunky bacon from being saved</h2><p>There were problems with the following fields:</p><ul><li>User email can't be empty</li><li>Author name can't be empty</li></ul></div>), error_messages_for(:user, :post, :object_name => "chunky_bacon")
-
     # hide header and explanation messages with nil or empty string
     assert_dom_equal %(<div class="errorExplanation" id="errorExplanation"><ul><li>User email can't be empty</li><li>Author name can't be empty</li></ul></div>), error_messages_for(:user, :post, :header_message => nil, :message => "")
 


### PR DESCRIPTION
# Summary

Merges the changes from the original fork in [jebw/dynamic_form](https://github.com/FlexMR/dynamic_form) which introduced this commit https://github.com/jebw/dynamic_form/commit/25dcbbe9ffcfa4cce86c4ace1d5b4a1c01dfbc04 into the [FlexMR/dynamic_form](https://github.com/FlexMR/dynamic_form) `master` branch. The summary of the changes are as follow:

```
If a model name comes from the translations (ie User.class.model_name.human)
or if it has been supplied by the user (options[:object_name]) then show it
as is.

Only rewrite underscores if it has been derived from the supplied model, i.e.

  error_messages_for :user
````

Once this has been done we can update the following in the FlexMR/flexmr project `Gemfile`:

```
gem 'dynamic_form', git: 'https://github.com/jebw/dynamic_form.git', ref: '25dcbbe9ffcfa4cce86c4ace1d5b4a1c01dfbc04', branch: 'old_css_names_without_rewrite'
```

This will then free us up to address a Rails 6.1 deprecation warning against this repository.

# Links

- JIRA card: [FMP-760](https://flexmr.atlassian.net/browse/FMP-760)

# Implementation Checklist

- [x] [OWASP](https://www.cloudflare.com/learning/security/threats/owasp-top-10/) and security best practices considered  
- [x] DB changes and migration implications considered
- [x] [Brakeman additions documented](https://github.com/FlexMR/flexmr/wiki/Brakeman) 
- [x] Dependencies documented